### PR TITLE
Component should use the output of optimize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function readSvg(options: Options = { type: 'component' }) {
           if (type === 'src' || (!type && options.type === 'src')) {
             data = `\nexport default \`${opt.data}\`;`
           } else {
-            const { js } = compile(data, {
+            const { js } = compile(opt.data, {
               css: false,
               filename: id,
               hydratable: true,


### PR DESCRIPTION
Right now, the svg is optimized, but only used when `?src` is used. The Svelte Component doesn't use the optimized output.
This PR fixes that.