### PR TITLE
Update `transform` params for Vite 2.7.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,22 @@ function addComponentProps(data: string): string {
   return `${head} {...$$props}${body}`
 }
 
+// TODO: Remove this when Vite 2.7.0 is well-adopted.
+// https://github.com/vitejs/vite/blob/v2.7.1/packages/vite/CHANGELOG.md#270-2021-12-07
+function getSsrOption(transformOptions: boolean | { ssr: boolean }) {
+  return typeof transformOptions === 'object' ? transformOptions.ssr : transformOptions
+}
+
 function readSvg(options: Options = { type: 'component' }) {
   const resvg = /\.svg(?:\?(src|url|component))?$/
   const cache = new Map()
 
   return {
     name: 'sveltekit-svg',
-    async transform(source: string, id: string, isBuild: boolean) {
+    async transform(source: string, id: string, transformOptions: boolean | { ssr: boolean }) {
       const match = id.match(resvg)
+
+      const isBuild = getSsrOption(transformOptions)
 
       if (match) {
         const type = match[1]


### PR DESCRIPTION
The plugin blows up on Vite 2.7.0 because of the API change on the transform (https://github.com/vitejs/vite/blob/v2.7.1/packages/vite/CHANGELOG.md#270-2021-12-07). This is a quick (temporary) fix until 2.7.0 is more widely adopted and the plugin won't need to support both.