### PR TITLE
Pass filename to svgo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,8 +102,10 @@ function readSvg(options: Options = { type: 'component' }) {
           let data = (await readFile(filename)).toString('utf-8')
           // The typedef if wrong. The actual method expects options to be
           // an object or null
-          // @ts-expect-error
-          const opt = optimize(data, options.svgoOptions || null)
+          const opt = optimize(data, {
+            path: filename,
+            ...(options.svgoOptions || {}),
+          })
 
           if (type === 'src' || (!type && options.type === 'src')) {
             data = `\nexport default \`${opt.data}\`;`


### PR DESCRIPTION
This enables plugins to access the `svg`'s path.

It is also recommended by `svgo`'s docs:
https://github.com/svg/svgo/tree/1b88baa123d9878c5b7de5bdc5350e1d7160cf35#optimize