### PR TITLE
Allow to skip SVGO

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ function readSvg(options: Options = { type: 'component' }) {
           const opt = options.svgoOptions !== false ? optimize(data, {
             path: filename,
             ...(options.svgoOptions || {}),
-          }) : data;
+          }) : { data };
 
           if (type === 'src' || (!type && options.type === 'src')) {
             data = `\nexport default \`${opt.data}\`;`

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ interface Options {
   /**
    * Verbatim [SVGO](https://github.com/svg/svgo) options
    */
-  svgoOptions?: OptimizeOptions
+  svgoOptions?: OptimizeOptions | false
   /**
    * Paths to apply the SVG plugin on. This can be useful if you want to apply
    * different SVGO options/plugins on different SVGs.
@@ -101,10 +101,10 @@ function readSvg(options: Options = { type: 'component' }) {
 
           const filename = id.replace(/\.svg(\?.*)$/, '.svg')
           let data = (await readFile(filename)).toString('utf-8')
-          const opt = optimize(data, {
+          const opt = options.svgoOptions !== false ? optimize(data, {
             path: filename,
             ...(options.svgoOptions || {}),
-          })
+          }) : data;
 
           if (type === 'src' || (!type && options.type === 'src')) {
             data = `\nexport default \`${opt.data}\`;`


### PR DESCRIPTION
There are some situations where we don't want to optimize SVGs. 

For instance, when SVGs are the target of CSS animations, optimization can mess things up. Also, some project just optimize SVGs statically and there's simply no point in running SVGO **again** on already optimized code.

I suggest that when `svgOptions` is explicitly set to `false` this library can interpret that as completely disabling the SVGO pass. We can make it with a dedicated option, but I thought that reusing this one was ok.

Let me know what you think.