### PR TITLE
Use `vite.config.js` instead of `svelte.config.js` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,62 +10,51 @@ components, inline SVG code or urls.
 
 ## Usage
 
-In your `svelte.config.js`
+In your `vite.config.js`
 
 ```js
-import svg from '@poppanator/sveltekit-svg'
+import { sveltekit } from '@sveltejs/kit/vite';
+import svg from '@poppanator/sveltekit-svg';
 
-/** @type {import('@sveltejs/kit').Config} */
+/** @type {import('vite').UserConfig} */
 const config = {
-  ...,
+  plugins: [
+    sveltekit(),
+    svg(options) // Options are optional
+  ],
+};
 
-  kit: {
-    ...,
-    vite: {
-      // Options are optional
-      plugins: [svg(options)]
-    }
-  }
-}
-
-export default config
+export default config;
 ```
 
 You can also pass multiple `svg` transformers based on paths if you want to
 apply different SVGO options for different SVGs
 
 ```js
-/** @type {import('@sveltejs/kit').Config} */
 const config = {
-  ...,
-
-  kit: {
-    ...,
-    vite: {
-      plugins: [
-        svg({
-          includePaths: ["./src/lib/icons/", "./src/assets/icons/"],
-          svgoOptions: {
-            multipass: true,
-            plugins: [{
-              name: "preset-default",
-              // by default svgo removes the viewBox which prevents svg icons from scaling
-              // not a good idea! https://github.com/svg/svgo/pull/1461
-              params: { overrides: { removeViewBox: false } }
-            },
-            { name: "removeAttrs", params: { attrs: "(fill|stroke)" }}],
-          },
-        }),
-        svg({
-          includePaths: ["./src/lib/graphics/"],
-          svgoOptions: {
-            multipass: true,
-            plugins: ["preset-default" ],
-          },
-        }),
-      ]
-    }
-  }
+  plugins: [
+    sveltekit(),
+    svg({
+      includePaths: ["./src/lib/icons/", "./src/assets/icons/"],
+      svgoOptions: {
+        multipass: true,
+        plugins: [{
+          name: "preset-default",
+          // by default svgo removes the viewBox which prevents svg icons from scaling
+          // not a good idea! https://github.com/svg/svgo/pull/1461
+          params: { overrides: { removeViewBox: false } }
+        },
+        { name: "removeAttrs", params: { attrs: "(fill|stroke)" } }],
+      },
+    }),
+    svg({
+      includePaths: ["./src/lib/graphics/"],
+      svgoOptions: {
+        multipass: true,
+        plugins: ["preset-default"],
+      },
+    }),
+  ]
 }
 ```
 


### PR DESCRIPTION
SvelteKit now uses two separate `vite.config.js` and `svelte.config.js` files and custom plugins should be configured in `vite.config.js` — see [this](https://kit.svelte.dev/docs/project-structure#project-files-vite-config-js).

I updated the README to reflect this.