### PR TITLE
Render the contents of the `<svg>` tag using `{@html}` in the component mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,17 +201,15 @@ where `src/lib/EmptyIcon.svelte` can contain just `<svg />`.
 ## Typescript
 
 For Typescript not to complain about `file.svg?component` et.al, add the
-following to something like `svg.d.ts` (somewhere in the path of your project where 
+following to something like `svg.d.ts` (somewhere in the path of your project where
 `tsc` can find it).
 
 ```ts
 declare module '*.svg?component' {
-  import type { ComponentType, SvelteComponentTyped } from 'svelte'
+  import type { ComponentType, SvelteComponent } from 'svelte'
   import type { SVGAttributes } from 'svelte/elements'
 
-  const content: ComponentType<
-    SvelteComponentTyped<SVGAttributes<SVGSVGElement>>
-  >
+  const content: ComponentType<SvelteComponent<SVGAttributes<SVGSVGElement>>>
 
   export default content
 }

--- a/README.md
+++ b/README.md
@@ -201,46 +201,9 @@ where `src/lib/EmptyIcon.svelte` can contain just `<svg />`.
 ## Typescript
 
 For Typescript not to complain about `file.svg?component` et.al, add the
-following to something like `svg.d.ts` (somewhere in the path of your project where
-`tsc` can find it).
+following import statement to `src/app.d.ts` (or any `.d.ts` file somewhere in the path of your
+project where `tsc` can find it).
 
 ```ts
-declare module '*.svg?component' {
-  import type { ComponentType, SvelteComponent } from 'svelte'
-  import type { SVGAttributes } from 'svelte/elements'
-
-  const content: ComponentType<SvelteComponent<SVGAttributes<SVGSVGElement>>>
-
-  export default content
-}
-
-declare module '*.svg?src' {
-  const content: string
-  export default content
-}
-
-declare module '*.svg?url' {
-  const content: string
-  export default content
-}
-
-declare module '*.svg?dataurl' {
-  const content: string
-  export default content
-}
-
-declare module '*.svg?dataurl=base64' {
-  const content: string
-  export default content
-}
-
-declare module '*.svg?dataurl=enc' {
-  const content: string
-  export default content
-}
-
-declare module '*.svg?dataurl=unenc' {
-  const content: string
-  export default content
-}
+import '@poppanator/sveltekit-svg/dist/svg'
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ function isCompileError(err: unknown): err is CompileError {
   return err instanceof Error && 'code' in err && 'frame' in err
 }
 
-const svgRegex = /(<svg.*?)(>.*)/s
+const svgRegex = /<svg(.*?)>(.*?)<\/svg>/s
 
 function color(start: string, end = '\u001b[0m'): (text: string) => string {
   return (text: string) => `${start}${text}${end}`
@@ -76,8 +76,9 @@ function addComponentProps(data: string): string {
     throw new Error('Invalid SVG')
   }
 
-  const [, head, body] = parts
-  return `${head} {...$$props}${body}`
+  const [, attributes, content] = parts
+  const contentEscaped = content?.replace(/\${/g, '\\${')
+  return `<svg ${attributes} {...$$props}>{@html \`${contentEscaped}\`}</svg>`
 }
 
 function isSvgoOptimizeError(obj: unknown): obj is Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,10 @@ function addComponentProps(data: string): string {
   }
 
   const [, attributes, content] = parts
-  const contentEscaped = content?.replace(/\${/g, '\\${')
+  const contentEscaped = content
+    ?.replace(/\\/g, '\\\\') // escape backslashes (\)
+    .replace(/`/g, '\\`') // escape backticks (`)
+    .replace(/\${/g, '\\${') // escape ${
   return `<svg ${attributes} {...$$props}>{@html \`${contentEscaped}\`}</svg>`
 }
 

--- a/svg.d.ts
+++ b/svg.d.ts
@@ -1,10 +1,8 @@
 declare module '*.svg?component' {
-  import type { ComponentType, SvelteComponentTyped } from 'svelte'
+  import type { ComponentType, SvelteComponent } from 'svelte'
   import type { SVGAttributes } from 'svelte/elements'
 
-  const content: ComponentType<
-    SvelteComponentTyped<SVGAttributes<SVGSVGElement>>
-  >
+  const content: ComponentType<SvelteComponent<SVGAttributes<SVGSVGElement>>>
 
   export default content
 }


### PR DESCRIPTION
Closes #39

I also replaced `SvelteComponentTyped` with `SvelteComponent` in `svg.d.ts` since `SvelteComponentTyped` is deprecated in Svelte 4 — see [this](https://svelte.dev/docs/v4-migration-guide#sveltecomponenttyped-is-deprecated).