### PR TITLE
SvelteComponent not needed as causing issues passing props

### DIFF
--- a/svg.d.ts
+++ b/svg.d.ts
@@ -2,7 +2,7 @@ declare module '*.svg?component' {
   import type { Component, SvelteComponent } from 'svelte'
   import type { SVGAttributes } from 'svelte/elements'
 
-  const content: Component<SvelteComponent<SVGAttributes<SVGSVGElement>>>
+  const content: Component<SVGAttributes<SVGSVGElement>>
 
   export default content
 }


### PR DESCRIPTION
#Since this type changed svelte5 does not need the `SvelteComponent` as this is was expecting children as a prop and not each props such as `class` etc.

This should fix the typing and allow us to pass svelte component attributes:

Before:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/8763ffe0-c976-4a36-8c59-8f81c14facf3">

After Requested Change:
<img width="567" alt="image" src="https://github.com/user-attachments/assets/7e9804c6-f2c7-42ab-ab21-1cae843e087c">


this may not be the correct approach so please add your two cents!

 #59 